### PR TITLE
dependency-review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v2


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review

"
Dependency review lets you catch insecure dependencies before you introduce them to your environment, and provides information on license, dependents, and age ...

By reviewing dependencies in a pull request, before merging, you can shift supply chain security left. Rather than Dependabot alerts notifying you of a vulnerability after you’ve introduced it to your environment, you can catch it before introducing it with dependency review. However, you still need both-after all, Dependabot alerts also notify you of new vulnerabilities that are discovered in existing dependencies.
"