### PR TITLE
Fix for matplotlib warning

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -20,6 +20,7 @@ env:
   # you might end up reusing a previous cache if it haven't been deleted already.
   # It applies 7 days retention policy by default.
   RESET_EXAMPLES_CACHE: 0
+  PYFLUENT_LAUNCH_CONTAINER: 1
 
 jobs:
 

--- a/src/ansys/fluent/visualization/matplotlib/plotter_defns.py
+++ b/src/ansys/fluent/visualization/matplotlib/plotter_defns.py
@@ -155,7 +155,7 @@ class Plotter:
         plt.title(self._title)
         plt.xlabel(self._xlabel)
         plt.ylabel(self._ylabel)
-        plt.legend(loc="upper right")
+        plt.legend(labels=self._curves, loc="upper right")
 
 
 class ProcessPlotter(Plotter):


### PR DESCRIPTION
Without labels matplotlib shows following warning:

_WARNING:matplotlib.legend:No artists with labels found to put in legend.  Note that artists whose label start with an underscore are ignored when legend() is called with no argument._