### PR TITLE
build: Group dependabot PRs and update frequency.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,17 @@ updates:
     directory: "/requirements" # Location of package manifests
     insecure-external-code-execution: allow
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "Maintenance"
       - "Dependencies"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     #ignore:
       #- dependency-name: "vtk"
       #- dependency-name: "grpcio"
@@ -15,4 +22,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    labels:
+      - "Maintenance"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
- Dependabot should now group minor and patch (not major) dependency updates into a single PR
- Reduced frequency of dependency updates from daily to monthly
- GitHub actions dependency updates will all be grouped into a single monthly PR
- Added Maintenance label to GitHub actions dependabot PRs

This has been done following the PR by @raph-luc in pyfluent repo. Thank you @raph-luc.