### PR TITLE
build: Bump version to 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-fluent-visualization"
-version = "0.11.dev0"
+version = "0.11.0"
 description = "A python wrapper for ansys Fluent visualization"
 license = "MIT"
 authors = ["ANSYS, Inc. <ansys.support@ansys.com>"]
@@ -25,7 +25,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 importlib-metadata = {version = "^4.0", python = "<3.9"}
-ansys-fluent-core = "~=0.22.dev0"
+ansys-fluent-core = ">=0.23.dev0"
 vtk = ">=9.3.0.rc0"
 pyvista = ">=0.39.0"
 pyvistaqt = ">=0.7.0"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,4 +2,4 @@ from ansys.fluent.visualization import __version__
 
 
 def test_pkg_version():
-    assert __version__ == "0.11.dev0"
+    assert __version__ == "0.11.0"


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent-visualization/issues/411

Bump version to 0.11.0 due to core package release.