### PR TITLE
ci: Support Python 3.13

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
     steps:

--- a/.github/workflows/nightly-test-run.yml
+++ b/.github/workflows/nightly-test-run.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>
 Installation
 ------------
 The ``ansys-fluent-visualization`` package supports Python 3.10 through Python
-3.12 on Windows and Linux.
+3.13 on Windows and Linux.
 
 If you are using Python 3.10, download and install the wheel file for the ``vtk`` package from
 `here for Windows <https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl>`_

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -14,7 +14,7 @@ page on the Ansys website.
 Install package
 ***************
 The ``ansys-fluent-visualization`` package supports Python 3.10 through
-Python 3.12 on Windows and Linux.
+Python 3.13 on Windows and Linux.
 
 Install the latest release from `PyPi
 <https://pypi.org/project/ansys-fluent-visualization/>`_ with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ packages = [
 python = ">=3.10,<4.0"
 importlib-metadata = {version = "^4.0", python = "<3.9"}
 ansys-fluent-core = "~=0.27.dev0"
-pyvista = "~=0.44.1"
-pyvistaqt = "~=0.11.1"
-pyside6 = "~=6.7.2"
+pyvista = ">=0.44.1"
+pyvistaqt = ">=0.11.1"
+pyside6 = ">=6.7.2"
 matplotlib = ">=3.9.0"
 
 [tool.poetry.urls]


### PR DESCRIPTION
Also, some thirdparty dependency specs have been changed from compatible to min version. `pyside6~=6.7.2` could not be installed in Python 3.13.

@prmukherj We'll need a release for the dependency version change.