### PR TITLE
feat: Expose renderer.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -164,7 +164,7 @@ sphinx_gallery_conf = {
     "filename_pattern": r"\.py",
     # Disabled example scripts
     "ignore_pattern": r"script_manifold\.py|post_processing_exhaust_manifold\.py|"
-    r"updated_script_manifold_example\.py|flycheck*",
+    r"updated_script_manifold_example\.py|enhanced_postprocessing\.py|flycheck*",
     # Remove the "Download all examples" button from the top level gallery
     "download_all_examples": False,
     # Sort gallery example by file name instead of number of lines (default)

--- a/examples/00-postprocessing/enhanced_postprocessing.py
+++ b/examples/00-postprocessing/enhanced_postprocessing.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+""".. _ref_enhanced_postprocessing:
+
+Enhanced Postprocessing
+-----------------------
+This example demonstrates access to the actual renderer from the pyfluent
+renderer layer so that users can perform operations on it.
+"""
+
+###############################################################################
+# Perform required imports
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+# Perform required imports and set the configuration.
+
+import ansys.fluent.core as pyfluent
+from ansys.fluent.core import examples
+from ansys.fluent.core.solver import (
+    PressureOutlets,
+    WallBoundaries,
+    using,
+)
+from ansys.units import VariableCatalog
+
+from ansys.fluent.visualization import (
+    GraphicsWindow,
+    Mesh,
+    Monitor,
+    XYPlot,
+    config,
+)
+
+pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
+
+config.interactive = False
+config.view = "isometric"
+
+###############################################################################
+# Download files and launch Fluent
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Download the case and data files and launch Fluent as a service in solver
+# mode with double precision and two processors. Read in the case and data
+# files.
+
+import_case = examples.download_file(
+    file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system"
+)
+
+import_data = examples.download_file(
+    file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system"
+)
+
+solver_session = pyfluent.launch_fluent(
+    precision=pyfluent.Precision.DOUBLE,
+    processor_count=2,
+    start_transcript=False,
+    mode=pyfluent.FluentMode.SOLVER,
+)
+
+solver_session.settings.file.read_case(file_name=import_case)
+solver_session.settings.file.read_data(file_name=import_data)
+
+with using(solver_session):
+
+    # Create a graphics object for the mesh display.
+    graphics_window = GraphicsWindow()
+
+    mesh = Mesh(show_edges=True, surfaces=WallBoundaries())
+    graphics_window.add_graphics(mesh, position=(0, 0))
+    mesh = Mesh(surfaces=WallBoundaries())
+    graphics_window.add_graphics(mesh, position=(0, 1))
+
+    graphics_window.renderer.set_background("black", top="white")
+    graphics_window.save_graphics("sample_mesh_image.pdf")
+    graphics_window.renderer.set_background("white")
+    graphics_window.show()
+
+    # Create and display XY plot, residual plot and solve and plot solution monitors.
+    plot_window = GraphicsWindow()
+
+    xy_plot_object = XYPlot(
+        surfaces=PressureOutlets(), y_axis_function=VariableCatalog.TEMPERATURE
+    )
+    plot_window.add_plot(xy_plot_object, position=(0, 0), title="Temperature")
+
+    residual = Monitor(monitor_set_name="residual")
+    plot_window.add_plot(residual, position=(0, 1))
+    plot_window.save_graphics("sample_plot.pdf")
+    plot_window.show()
+
+    plot_window.renderer = "matplotlib"
+    plot_window.save_graphics("sample_plot.png")
+    plot_window.show()

--- a/examples/00-postprocessing/updated_post_processing_example.py
+++ b/examples/00-postprocessing/updated_post_processing_example.py
@@ -47,6 +47,9 @@ The new design provides a streamlined workflow for exploring and analyzing
 the temperature and flow characteristics in the exhaust manifold.
 
 """
+###############################################################################
+# Run the following in command prompt to execute this file:
+# exec(open("updated_post_processing_example.py").read())
 
 ###############################################################################
 # Perform required imports
@@ -230,4 +233,7 @@ with using(solver_session):
     point_vel_rplot = Monitor(monitor_set_name="point-vel-rplot")
     plot_window.add_plot(point_vel_rplot, position=(1, 1))
 
+    plot_window.show()
+
+    plot_window.renderer = "matplotlib"
     plot_window.show()

--- a/src/ansys/fluent/visualization/graphics/graphics_windows.py
+++ b/src/ansys/fluent/visualization/graphics/graphics_windows.py
@@ -41,13 +41,13 @@ class _GraphicsWindow:
     """
 
     def __init__(
-        self, wind_id, grid: tuple = (1, 1), renderer=None, graphics_objs=None
+        self, window_id, grid: tuple = (1, 1), renderer=None, graphics_objs=None
     ):
         """__init__ method of GraphicsWindow class."""
         self._grid = grid
         self._graphics_objs = graphics_objs
         self.window_id = graphics_windows_manager.open_window(
-            window_id=wind_id,
+            window_id=window_id,
             grid=self._grid,
             renderer=renderer,
         )

--- a/src/ansys/fluent/visualization/graphics/graphics_windows.py
+++ b/src/ansys/fluent/visualization/graphics/graphics_windows.py
@@ -40,17 +40,14 @@ class _GraphicsWindow:
     save, animate, etc. on graphics objects.
     """
 
-    def __init__(self, grid: tuple = (1, 1)):
+    def __init__(
+        self, wind_id, grid: tuple = (1, 1), renderer=None, graphics_objs=None
+    ):
         """__init__ method of GraphicsWindow class."""
         self._grid = grid
-        self._graphics_objs = []
-        self.window_id = None
-
-    def show(self, wind_id, renderer=None) -> None:
-        """Render the objects in window and display the same."""
-        self.window_id = wind_id
+        self._graphics_objs = graphics_objs
         self.window_id = graphics_windows_manager.open_window(
-            window_id=self.window_id,
+            window_id=wind_id,
             grid=self._grid,
             renderer=renderer,
         )

--- a/src/ansys/fluent/visualization/graphics/graphics_windows_manager.py
+++ b/src/ansys/fluent/visualization/graphics/graphics_windows_manager.py
@@ -158,6 +158,7 @@ class GraphicsWindow(VisualizationWindow):
         """Render graphics."""
         self._render_graphics()
         self.renderer.render(self._object_list_to_render)
+        self.renderer.show()
 
     def _render_graphics(self, obj_dict=None):
         """Render graphics."""

--- a/src/ansys/fluent/visualization/graphics/pyvista/renderer.py
+++ b/src/ansys/fluent/visualization/graphics/pyvista/renderer.py
@@ -188,7 +188,6 @@ class Renderer(AbstractRenderer):
                     if "title" in mesh_dict:
                         chart.title = mesh_dict.pop("title")
                     self.plotter.add_chart(chart, **mesh_dict)
-        self.plotter.show()
 
     def save_graphic(self, file_name: str):
         """Save graphics to the specified file.

--- a/src/ansys/fluent/visualization/plotter/matplotlib/renderer.py
+++ b/src/ansys/fluent/visualization/plotter/matplotlib/renderer.py
@@ -171,9 +171,6 @@ class Plotter(AbstractRenderer):
                         )
                 except KeyError:
                     pass
-        if not self._visible:
-            self._visible = True
-            plt.show()
 
     def show(self):
         if not self._visible:
@@ -292,7 +289,7 @@ class ProcessPlotter(Plotter):
                         name = data["save_graphic"]
                         self.save_graphic(name)
                     else:
-                        self.render(data_object_list=data["data"])
+                        self.render(meshes=data["data"])
             self.fig.canvas.draw()
         except BrokenPipeError:
             self.close()

--- a/src/ansys/fluent/visualization/plotter/plotter_windows.py
+++ b/src/ansys/fluent/visualization/plotter/plotter_windows.py
@@ -24,11 +24,17 @@ from ansys.fluent.visualization.plotter import plotter_windows_manager
 
 
 class _PlotterWindow:
-    def __init__(self, grid: tuple = (1, 1)):
+    def __init__(self, win_id, grid: tuple = (1, 1), renderer=None, plot_objs=None):
         self._grid = grid
-        self._plot_objs = []
+        self._plot_objs = plot_objs
         self._subplot_titles = []
-        self.window_id = None
+        self.window_id = plotter_windows_manager.open_window(
+            window_id=win_id, grid=self._grid, renderer=renderer
+        )
+        self._populate_subplot_titles()
+        plotter_windows_manager.plot_graphics(self._plot_objs, self.window_id)
+        self.plotter_window = plotter_windows_manager._post_windows.get(self.window_id)
+        self.plotter = self.plotter_window.plotter
 
     def add_plots(self, object, position: tuple = (0, 0), title: str = "") -> None:
         """Add data to a plot.
@@ -54,16 +60,6 @@ class _PlotterWindow:
                 )
             else:
                 self._subplot_titles.append("XYPlot")
-
-    def show(self, win_id=None, renderer=None) -> None:
-        """Render the objects in window and display the same."""
-        self._populate_subplot_titles()
-        self.window_id = plotter_windows_manager.open_window(
-            window_id=win_id, grid=self._grid, renderer=renderer
-        )
-        self.plotter_window = plotter_windows_manager._post_windows.get(self.window_id)
-        self.plotter = self.plotter_window.plotter
-        plotter_windows_manager.plot_graphics(self._plot_objs, self.window_id)
 
     def save_graphic(
         self,

--- a/src/ansys/fluent/visualization/plotter/plotter_windows.py
+++ b/src/ansys/fluent/visualization/plotter/plotter_windows.py
@@ -24,12 +24,12 @@ from ansys.fluent.visualization.plotter import plotter_windows_manager
 
 
 class _PlotterWindow:
-    def __init__(self, win_id, grid: tuple = (1, 1), renderer=None, plot_objs=None):
+    def __init__(self, window_id, grid: tuple = (1, 1), renderer=None, plot_objs=None):
         self._grid = grid
         self._plot_objs = plot_objs
         self._subplot_titles = []
         self.window_id = plotter_windows_manager.open_window(
-            window_id=win_id, grid=self._grid, renderer=renderer
+            window_id=window_id, grid=self._grid, renderer=renderer
         )
         self._populate_subplot_titles()
         plotter_windows_manager.plot_graphics(self._plot_objs, self.window_id)

--- a/src/ansys/fluent/visualization/plotter/plotter_windows_manager.py
+++ b/src/ansys/fluent/visualization/plotter/plotter_windows_manager.py
@@ -149,6 +149,7 @@ class PlotterWindow(VisualizationWindow):
                 ]
             )
             self.plotter.render(self._object_list_to_render)
+            self.plotter.show()
 
     def plot_graphics(self, object_list):
         self._obj_list = object_list

--- a/src/ansys/fluent/visualization/plotter/pyvista/renderer.py
+++ b/src/ansys/fluent/visualization/plotter/pyvista/renderer.py
@@ -140,12 +140,9 @@ class Plotter(AbstractRenderer):
                 if self._max_y and self._min_y:
                     if self._yscale == "log":
                         self.chart.y_axis.log_scale = True
-        self.plotter.show()
 
     def show(self):
-        if not self._visible:
-            self._visible = True
-            self.plotter.show()
+        self.plotter.show()
 
     def close(self):
         """Close window."""

--- a/src/ansys/fluent/visualization/plotter/pyvista/renderer.py
+++ b/src/ansys/fluent/visualization/plotter/pyvista/renderer.py
@@ -142,7 +142,8 @@ class Plotter(AbstractRenderer):
                         self.chart.y_axis.log_scale = True
 
     def show(self):
-        self.plotter.show()
+        if self.plotter:
+            self.plotter.show()
 
     def close(self):
         """Close window."""

--- a/src/ansys/fluent/visualization/renderer.py
+++ b/src/ansys/fluent/visualization/renderer.py
@@ -221,10 +221,12 @@ class GraphicsWindow:
     def renderer(self):
         """Returns the plotter object."""
         self._update_renderer()
-        try:
+        if (
+            hasattr(self._renderer.plotter, "plotter")
+            and self._renderer.plotter.plotter is not None
+        ):
             return self._renderer.plotter.plotter
-        except AttributeError:
-            return self._renderer.plotter
+        return self._renderer.plotter
 
     @renderer.setter
     def renderer(self, name: str):

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -376,7 +376,7 @@ def test_visualization_calls_render_correctly_with_xy_plot_pyvista(
         )
         plot_window = GraphicsWindow()
         plot_window.add_plot(xy_plot_object)
-        plot_window.renderer
+        plot_window.show()
 
         # Check that render was called 1 time
         mock_render.assert_called_once()
@@ -433,7 +433,7 @@ def test_visualization_calls_render_correctly_with_monitor_plot(
         residual.monitor_set_name = "residual"
         plot_window = GraphicsWindow()
         plot_window.add_plot(residual)
-        plot_window.renderer
+        plot_window.show()
 
         # Check that render was called 1 time for 1 surface
         mock_render.assert_called_once()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -376,7 +376,7 @@ def test_visualization_calls_render_correctly_with_xy_plot_pyvista(
         )
         plot_window = GraphicsWindow()
         plot_window.add_plot(xy_plot_object)
-        plot_window.show()
+        assert plot_window.renderer
 
         # Check that render was called 1 time
         mock_render.assert_called_once()
@@ -433,7 +433,7 @@ def test_visualization_calls_render_correctly_with_monitor_plot(
         residual.monitor_set_name = "residual"
         plot_window = GraphicsWindow()
         plot_window.add_plot(residual)
-        plot_window.show()
+        assert plot_window.renderer
 
         # Check that render was called 1 time for 1 surface
         mock_render.assert_called_once()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -376,7 +376,7 @@ def test_visualization_calls_render_correctly_with_xy_plot_pyvista(
         )
         plot_window = GraphicsWindow()
         plot_window.add_plot(xy_plot_object)
-        assert plot_window.renderer
+        plot_window.renderer
 
         # Check that render was called 1 time
         mock_render.assert_called_once()
@@ -433,7 +433,7 @@ def test_visualization_calls_render_correctly_with_monitor_plot(
         residual.monitor_set_name = "residual"
         plot_window = GraphicsWindow()
         plot_window.add_plot(residual)
-        assert plot_window.renderer
+        plot_window.renderer
 
         # Check that render was called 1 time for 1 surface
         mock_render.assert_called_once()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -404,9 +404,9 @@ def test_visualization_calls_render_correctly_with_xy_plot_matplotlib(
             surfaces=["outlet"],
             y_axis_function="temperature",
         )
-        plot_window = GraphicsWindow()
+        plot_window = GraphicsWindow(renderer="matplotlib")
         plot_window.add_plot(xy_plot_object)
-        plot_window.show(renderer="matplotlib")
+        plot_window.show()
 
         # Check that render was called 1 time for 1 surface
         mock_render.assert_called_once()


### PR DESCRIPTION
 Expose renderer even for non-interactive plotter.
 This resolves bugs with renderer properties like save_graphics even in the non-interactive mode.
 
 Now the usages like below one are supported.
 
 >>> graphics_window.renderer.set_background("black", top="white")
 
 
 Please see example: "enhanced_postprocessing.py" for detailed usages.